### PR TITLE
Fix linter warning + improve readme + check_process

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Archivist is automatically launched periodicaly to update your backups and send 
 
 
 **Shipped version:** 1.3.3~ynh1
+
 ## Disclaimers / important information
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Have a look to the [security audit](https://defuse.ca/audits/encfs.htm) to have 
 
 ## Documentation and resources
 
-* Official app website: <https://github.com/maniackcrudelis/archivist>
 * Upstream app code repository: <https://github.com/maniackcrudelis/archivist>
 * YunoHost documentation for this app: <https://yunohost.org/app_archivist>
 * Report a bug: <https://github.com/YunoHost-Apps/archivist_ynh/issues>

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Have a look to the [security audit](https://defuse.ca/audits/encfs.htm) to have 
 ## Documentation and resources
 
 * Upstream app code repository: <https://github.com/maniackcrudelis/archivist>
-* YunoHost documentation for this app: <https://yunohost.org/app_archivist>
+* YunoHost Store: <https://apps.yunohost.org/app/archivist>
 * Report a bug: <https://github.com/YunoHost-Apps/archivist_ynh/issues>
 
 ## Developer info

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Archivist is automatically launched periodicaly to update your backups and send 
 
 
 
-**Shipped version:** 1.3.2~ynh2
+**Shipped version:** 1.3.3~ynh1
 ## Disclaimers / important information
 
 ## Configuration

--- a/README_fr.md
+++ b/README_fr.md
@@ -40,7 +40,7 @@ Consultez l'[audit de sécurité](https://defuse.ca/audits/encfs.htm) pour avoir
 ## Documentations et ressources
 
 * Dépôt de code officiel de l’app : <https://github.com/maniackcrudelis/archivist>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_archivist>
+* YunoHost Store: <https://apps.yunohost.org/app/archivist>
 * Signaler un bug : <https://github.com/YunoHost-Apps/archivist_ynh/issues>
 
 ## Informations pour les développeurs

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,7 +22,8 @@ Vos sauvegardes peuvent être envoyées à de nombreux autres endroits, locaux o
 Archivist est automatiquement lancé périodiquement pour mettre à jour vos sauvegardes et envoyer les modifications aux autres emplacements.
 
 
-**Version incluse :** 1.3.3~ynh1
+**Version incluse :** 1.3.3~ynh1
+
 ## Avertissements / informations importantes
 
 ## Configuration

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,7 +22,7 @@ Vos sauvegardes peuvent être envoyées à de nombreux autres endroits, locaux o
 Archivist est automatiquement lancé périodiquement pour mettre à jour vos sauvegardes et envoyer les modifications aux autres emplacements.
 
 
-**Version incluse :** 1.3.2~ynh2
+**Version incluse :** 1.3.3~ynh1
 ## Avertissements / informations importantes
 
 ## Configuration

--- a/README_fr.md
+++ b/README_fr.md
@@ -39,7 +39,6 @@ Consultez l'[audit de sécurité](https://defuse.ca/audits/encfs.htm) pour avoir
 
 ## Documentations et ressources
 
-* Site officiel de l’app : <https://github.com/maniackcrudelis/archivist>
 * Dépôt de code officiel de l’app : <https://github.com/maniackcrudelis/archivist>
 * YunoHost Store: <https://apps.yunohost.org/app/archivist>
 * Signaler un bug : <https://github.com/YunoHost-Apps/archivist_ynh/issues>

--- a/README_fr.md
+++ b/README_fr.md
@@ -39,7 +39,6 @@ Consultez l'[audit de sécurité](https://defuse.ca/audits/encfs.htm) pour avoir
 
 ## Documentations et ressources
 
-* Site officiel de l’app : <https://github.com/maniackcrudelis/archivist>
 * Dépôt de code officiel de l’app : <https://github.com/maniackcrudelis/archivist>
 * Documentation YunoHost pour cette app : <https://yunohost.org/app_archivist>
 * Signaler un bug : <https://github.com/YunoHost-Apps/archivist_ynh/issues>

--- a/check_process
+++ b/check_process
@@ -5,15 +5,6 @@
 		core_backup=1
 		apps_backup=1
 		frequency="Weekly"
-	; Config_panel
-		main.encryption.encrypt=1|0
-		main.encryption.encryption_pwd=password1|password2
-		main.backup_types.core_backup=1|0
-		main.backup_types.apps_backup=1|0
-		main.backup_options.frequency=Daily|Each 3 days|Weekly|Biweekly|Monthly
-		main.backup_options.max_size=1000
-		main.overwrite_files.overwrite_cron=1|0
-		main.global_config.email_type=1|0
 	; Checks
 		pkg_linter=1
 		setup_sub_dir=0
@@ -22,26 +13,16 @@
 		setup_private=0
 		setup_public=0
 		upgrade=1
-		upgrade=1	from_commit=2b2793737d5e1374659cbb74838d10162a2147e6
+		#upgrade=1	from_commit=2b2793737d5e1374659cbb74838d10162a2147e6
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
 		change_url=0
 		config_panel=0
-;; Test actions without encryption
-# Actions can't be tested with the encryption on, because LXC does not support fuse.
-	; Manifest
-		encrypt=0
-		encryption_pwd=""
-		core_backup=1
-		apps_backup=1
-	; Checks
-		setup_nourl=1
-		actions=1
 ;;; Options
 Email=
 Notification=change
 ;;; Upgrade options
-	; commit=2b2793737d5e1374659cbb74838d10162a2147e6
-		name=03 Nov 2017 2b2793737d5e1374659cbb74838d10162a2147e6
+	; #commit=2b2793737d5e1374659cbb74838d10162a2147e6
+		#name=03 Nov 2017 2b2793737d5e1374659cbb74838d10162a2147e6
 		manifest_arg=encrypt=1&encryption_pwd="password"&core_backup=1&apps_backup=1&frequency="Weekly"&

--- a/manifest.json
+++ b/manifest.json
@@ -70,7 +70,7 @@
             },
             {
                 "name": "frequency",
-                "type": "string",
+                "type": "select",
                 "ask": {
                     "en": "Choose the frequency of your backups?",
                     "fr": "Choississez la fréquence de votre backup ?"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,6 @@
     "url": "https://github.com/maniackcrudelis/archivist",
     "upstream": {
         "license": "GPL-3.0",
-        "website": "https://github.com/maniackcrudelis/archivist",
         "code": "https://github.com/maniackcrudelis/archivist"
     },
     "license": "GPL-3.0",

--- a/scripts/install
+++ b/scripts/install
@@ -181,9 +181,7 @@ ynh_use_logrotate
 # PRINT INFORMATION
 #=================================================
 
-Informations="
-To add recipients or to modify the files or apps to backup,
-please have a look to the config file $config_file"
+Informations="To add recipients or to modify the files or apps to backup,please have a look to the config file $config_file"
 ynh_print_info --message="$Informations"
 
 #=================================================
@@ -192,10 +190,7 @@ ynh_print_info --message="$Informations"
 
 if [ "$encrypt" = "true" ]
 then
-	encrypt_message="Your password for encryption is '$encryption_pwd'
-
-"
-
+	encrypt_message="Your password for encryption is '$encryption_pwd'"
 else
 	encrypt_message=""
 fi


### PR DESCRIPTION
`Packagers: option frequency has 'choices' but has type 'string', use 'select' instead to remove this warning.`